### PR TITLE
Potential fix for code scanning alert no. 32: Shell command built from environment values

### DIFF
--- a/lib/yarn-version.ts
+++ b/lib/yarn-version.ts
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import semver from "semver";
 
 export const MINIMUM_YARN_CLASSIC_VERSION = "1.12.3";
@@ -31,7 +31,7 @@ export function getYarnVersion(yarnExec = "yarn", cwd?: string) {
   const key = `${yarnExec}:${cwd}`;
   let version = versionMap.get(key);
   if (version) return version;
-  version = execSync(`${yarnExec} -v`, { cwd }).toString().replace("\n", "");
+  version = execFileSync(yarnExec, ["-v"], { cwd }).toString().replace("\n", "");
   versionMap.set(key, version);
   return version;
 }


### PR DESCRIPTION
Potential fix for [https://github.com/quinnturner/audit-ci/security/code-scanning/32](https://github.com/quinnturner/audit-ci/security/code-scanning/32)

Use a non-shell child-process API and pass arguments separately so `yarnExec` is treated as a program path, not shell text.

Best fix in `lib/yarn-version.ts`:
- Replace `execSync` with `execFileSync` import from `node:child_process`.
- Change the version invocation from interpolated string to argument vector:
  - from: ``execSync(`${yarnExec} -v`, { cwd })``
  - to: `execFileSync(yarnExec, ["-v"], { cwd })`
- Keep behavior identical otherwise (same caching, trimming newline).

This removes shell interpretation and addresses both alert variants at the same location.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
