### PR TITLE
fix: improved error handling

### DIFF
--- a/lib/common.ts
+++ b/lib/common.ts
@@ -129,10 +129,22 @@ export function runProgram(
   let recentMessage: string;
   let errorMessage: string;
   proc.stdout.setEncoding("utf8");
+  if (proc.stderr) {
+    proc.stderr.setEncoding("utf8");
+    const stderrTransform = new ReadlineTransform({ skipEmpty: true });
+    proc.stderr.pipe(stderrTransform);
+    stderrTransform.on("data", (line: string) => {
+      try {
+        stderrListener(JSON.parse(line));
+      } catch {
+        stderrListener(line);
+      }
+    });
+  }
   proc.stdout
     .pipe(
       transform.on("error", (error: unknown) => {
-        throw error;
+        errorMessage = error instanceof Error ? error.message : String(error);
       }),
     )
     .pipe(
@@ -145,7 +157,6 @@ export function runProgram(
       // @ts-expect-error -- JSONStream.parse() accepts (pattern: any) when it should accept (pattern?: any)
       JSONStream.parse().on("error", () => {
         errorMessage = recentMessage;
-        throw new Error(errorMessage);
       }),
     )
     .pipe(

--- a/test/run-program.spec.ts
+++ b/test/run-program.spec.ts
@@ -48,6 +48,32 @@ describe("runProgram", () => {
     expect(stderr).toEqual(["not found"]);
   });
 
+  it("routes subprocess stderr to the stderr listener", async () => {
+    const stderr: unknown[] = [];
+    await runProgram(
+      process.execPath,
+      ["-e", 'console.error(JSON.stringify({ type: "error", data: "yarn failed" }))'],
+      { cwd: process.cwd() },
+      () => {},
+      (data) => {
+        stderr.push(data);
+      },
+    );
+    expect(stderr).toEqual([{ type: "error", data: "yarn failed" }]);
+  });
+
+  it("rejects when stdout is not valid JSON", async () => {
+    await expect(
+      runProgram(
+        process.execPath,
+        ["-e", "console.log('not json')"],
+        { cwd: process.cwd() },
+        () => {},
+        () => {},
+      ),
+    ).rejects.toThrow("not json");
+  });
+
   it("routes stdout listener errors to the stderr listener", async () => {
     const stderr: unknown[] = [];
     await runProgram(


### PR DESCRIPTION
stderr handling - Pipe proc.stderr into errorListener (or fail on non-empty stderr)
JSONStream errors - Reject promise instead of throwing in stream handler